### PR TITLE
Test and adjustment of spec agent

### DIFF
--- a/agents/create_specification_components.yml
+++ b/agents/create_specification_components.yml
@@ -20,11 +20,13 @@ static_prompt: |
   ## Source Priority
 
   Use sources in this priority order:
-  1. The component template from `drafts/components/`
+  1. The active component template from `drafts/components/`
   2. Existing specification artifacts from `specifications/`
-  3. Fallback/reference material from `component_drafts/`
+  3. Other designer-authored component drafts from `drafts/components/`
+  4. Fallback/reference material from `component_drafts/`
 
   If sources conflict:
+  - designer-authored component drafts in `drafts/components/` override fallback/reference material for named subcomponents
   - existing specification artifacts override fallback/reference material
   - explicit component-template content overrides fallback/reference material
 
@@ -52,6 +54,8 @@ static_prompt: |
   - properties are implied by the template behavior but not defined clearly enough for a usable specification
   - source conflicts cannot be resolved by the priority rules above
   - the provided context indicates a duplicate component identity
+  - a named subcomponent does not exist in either `drafts/components/` or `component_drafts/`
+  - a named subcomponent does not match an exact name in `draft_component_names` before checking `component_library_names`
 
   When blocking questions are needed:
   - do not output a finalized component specification
@@ -79,6 +83,7 @@ static_prompt: |
   You MUST:
   - stay strictly within the source material and authoritative specification context
   - treat fallback component-library files as reference only
+  - treat designer-authored component drafts in `drafts/components/` as the preferred library for missing subcomponents
 
   ## Forbidden Transformations
 
@@ -144,6 +149,15 @@ variable_prompt: |
 
   Fallback/reference component library artifacts (optional):
   {{input.component_library_references?}}
+
+  Designer-authored component drafts (optional):
+  {{input.draft_component_references?}}
+
+  Designer-authored component names (optional):
+  {{input.draft_component_names?}}
+
+  Fallback/reference component names (optional):
+  {{input.component_library_names?}}
 
   Dependency manifest (optional):
   {{input.direct_dependencies?}}

--- a/agents/create_specification_components.yml
+++ b/agents/create_specification_components.yml
@@ -21,17 +21,21 @@ static_prompt: |
 
   Use sources in this priority order:
   1. The active component template from `drafts/components/`
-  2. Existing specification artifacts from `specifications/`
-  3. Other designer-authored component drafts from `drafts/components/`
-  4. Fallback/reference material from `component_drafts/`
+  2. Active brand identity specification(s) provided for this run from `specifications/brands/` and `specifications/visuals/`
+  3. Existing specification artifacts from `specifications/`
+  4. Other designer-authored component drafts from `drafts/components/`
+  5. Fallback/reference material from `component_drafts/`
 
   If sources conflict:
+  - explicit component-template behavior and structure override brand styling inferences
+  - brand identity specifications constrain styling direction, feeling, tone, motion, iconography, typography, spacing intent, and token usage for this run
   - designer-authored component drafts in `drafts/components/` override fallback/reference material for named subcomponents
   - existing specification artifacts override fallback/reference material
   - explicit component-template content overrides fallback/reference material
 
   Components may rely on definitions already established in the specification context.
   Reuse or reference those definitions instead of redefining them.
+  Brand identity specifications are runtime-scoped, user-specific contract extensions; use the active brand specification set supplied in this run and never assume a built-in default brand.
 
   ## Guardrails
 
@@ -39,6 +43,8 @@ static_prompt: |
   - Each component must have a unique identity.
   - Variants and states must be explicit.
   - Styling guidance must come from existing specification definitions when present.
+  - When brand identity specifications are provided, every component must be checked against them so the resulting specification upholds the active project's brand standards.
+  - Brand influence must be integrated into existing sections such as Visual Structure, Variants, States, Properties, and Accessibility Notes instead of creating a separate brand section.
   - If essential information is missing, the component is incomplete and must block finalization.
 
   ## Blocking Clarification Rule
@@ -78,10 +84,13 @@ static_prompt: |
   - rephrase to remove ambiguity
   - organize content into the required section structure
   - convert prose into structured lists
+  - use the active brand identity specifications for this run as a contract extension for component feeling, style, motion, iconography, typography, spacing intent, and token usage
   - reference existing specification definitions when they are relevant to the component
 
   You MUST:
   - stay strictly within the source material and authoritative specification context
+  - inspect the provided active brand identity specifications for every component when they are available
+  - apply the supplied brand specification set for this run even when it differs between users or projects
   - treat fallback component-library files as reference only
   - treat designer-authored component drafts in `drafts/components/` as the preferred library for missing subcomponents
 
@@ -89,8 +98,10 @@ static_prompt: |
 
   You MUST NOT:
   - add new variants, states, properties, slots, or accessibility behavior
+  - invent brand rules, tokens, or stylistic requirements that do not appear in the provided runtime brand identity specifications or higher-priority component sources
   - add implementation/framework details
   - add independent styling systems when relevant design definitions already exist in specification context
+  - assume any default brand identity when no brand identity specification is provided
   - use fallback/reference material to override the component template or specification context
 
   ## Output Contract
@@ -146,6 +157,9 @@ variable_prompt: |
 
   Relevant specification artifacts (optional):
   {{input.existing_specifications?}}
+
+  Active brand identity specification artifacts for this run (optional):
+  {{input.brand_identity_specifications?}}
 
   Fallback/reference component library artifacts (optional):
   {{input.component_library_references?}}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4443,8 +4443,9 @@ mod tests {
         determine_specification_output_path, ensure_dev_dependency_entry,
         extract_actionable_blocking_bullets, extract_actionable_specification_blockers,
         extract_compile_error_message, finalize_specification_output,
-        generated_project_structure_paths, has_unfinished_specification, implementation_agent_name,
-        instructions_model_hash, parse_generated_files, resolve_input_files, sync_managed_block,
+        fit_context_to_token_limit, generated_project_structure_paths,
+        has_unfinished_specification, implementation_agent_name, instructions_model_hash,
+        parse_generated_files, resolve_input_files, sync_managed_block,
         validate_implementation_scaffold_ownership, CacheAgentInput, CategoryFilter, Config,
         ProcessSpecOutcome, BDD_TEST_TARGETS_END, BDD_TEST_TARGETS_START, DRAFTS_DIR,
     };
@@ -5746,6 +5747,196 @@ placeholder
         assert!(!executor
             .is_cache_hit(&draft_content, additional)
             .expect("cache miss after clear"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn component_context_includes_runtime_brand_identity_specs_from_active_workspace() {
+        let _cwd_guard = current_dir_lock().lock().expect("cwd lock");
+        let root = temp_root("component_brand_context");
+        fs::create_dir_all(root.join("drafts/components")).expect("mkdir drafts");
+        fs::create_dir_all(root.join("specifications/brands")).expect("mkdir brands");
+        fs::create_dir_all(root.join("specifications/visuals")).expect("mkdir visuals");
+
+        fs::write(root.join("drafts/components/button.md"), "# Button").expect("write draft");
+        fs::write(
+            root.join("specifications/brands/acme.md"),
+            "# Brand Identity Specification\n\n## Description\n- Brand A",
+        )
+        .expect("write brand spec");
+        fs::write(
+            root.join("specifications/visuals/snake_visuals.md"),
+            "# Brand Identity Specification\n\n## Description\n- Visual contract",
+        )
+        .expect("write visual spec");
+
+        let _dir_guard = CurrentDirGuard::enter(&root);
+        let draft_path = Path::new("drafts/components/button.md");
+        let draft_content = fs::read_to_string(draft_path).expect("read draft");
+        let additional = build_specification_context(draft_path, &draft_content, HashMap::new())
+            .expect("build specification context");
+
+        let brand_specs = additional
+            .get("brand_identity_specifications")
+            .and_then(|value| value.as_array())
+            .expect("brand identity specs array");
+        let brand_path = brand_specs[0]["path"]
+            .as_str()
+            .expect("brand path")
+            .replace('\\', "/");
+        let visual_path = brand_specs[1]["path"]
+            .as_str()
+            .expect("visual path")
+            .replace('\\', "/");
+
+        assert_eq!(brand_specs.len(), 2);
+        assert_eq!(brand_path, "specifications/brands/acme.md");
+        assert_eq!(visual_path, "specifications/visuals/snake_visuals.md");
+        assert!(brand_specs[0]["content"]
+            .as_str()
+            .expect("brand content")
+            .contains("Brand A"));
+        assert!(brand_specs[1]["content"]
+            .as_str()
+            .expect("visual content")
+            .contains("Visual contract"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn component_context_brand_identity_specs_are_scoped_to_each_project_root() {
+        let _cwd_guard = current_dir_lock().lock().expect("cwd lock");
+        let root_a = temp_root("component_brand_scope_a");
+        let root_b = temp_root("component_brand_scope_b");
+
+        for (root, brand_label) in [(&root_a, "Alpha"), (&root_b, "Beta")] {
+            fs::create_dir_all(root.join("drafts/components")).expect("mkdir drafts");
+            fs::create_dir_all(root.join("specifications/visuals")).expect("mkdir visuals");
+            fs::write(root.join("drafts/components/button.md"), "# Button").expect("write draft");
+            fs::write(
+                root.join("specifications/visuals/snake_visuals.md"),
+                format!("# Brand Identity Specification\n\n## Description\n- {brand_label}"),
+            )
+            .expect("write visual spec");
+        }
+
+        let context_a = {
+            let _dir_guard = CurrentDirGuard::enter(&root_a);
+            let draft_path = Path::new("drafts/components/button.md");
+            let draft_content = fs::read_to_string(draft_path).expect("read draft a");
+            build_specification_context(draft_path, &draft_content, HashMap::new())
+                .expect("build context a")
+        };
+        let context_b = {
+            let _dir_guard = CurrentDirGuard::enter(&root_b);
+            let draft_path = Path::new("drafts/components/button.md");
+            let draft_content = fs::read_to_string(draft_path).expect("read draft b");
+            build_specification_context(draft_path, &draft_content, HashMap::new())
+                .expect("build context b")
+        };
+
+        assert_ne!(
+            context_a.get("brand_identity_specifications"),
+            context_b.get("brand_identity_specifications")
+        );
+
+        let _ = fs::remove_dir_all(&root_a);
+        let _ = fs::remove_dir_all(&root_b);
+    }
+
+    #[test]
+    fn active_brand_spec_changes_component_cache_input() {
+        let _cwd_guard = current_dir_lock().lock().expect("cwd lock");
+        let root = temp_root("component_brand_cache");
+        fs::create_dir_all(root.join("drafts/components")).expect("mkdir drafts");
+        fs::create_dir_all(root.join("specifications/visuals")).expect("mkdir visuals");
+        fs::write(root.join("drafts/components/button.md"), "# Button").expect("write draft");
+
+        let _dir_guard = CurrentDirGuard::enter(&root);
+        let draft_path = Path::new("drafts/components/button.md");
+        let draft_content = fs::read_to_string(draft_path).expect("read draft");
+        let agent_name = "create_specification_components";
+        let instructions = FileAgentRegistry::new(None)
+            .get_specification(agent_name)
+            .expect("specification")
+            .canonical_for_cache();
+
+        fs::write(
+            Path::new("specifications/visuals/snake_visuals.md"),
+            "# Brand Identity Specification\n\n## Description\n- Version A",
+        )
+        .expect("write version a");
+        let context_a = build_specification_context(draft_path, &draft_content, HashMap::new())
+            .expect("context a");
+        let runner_input_a = build_agent_input(agent_name, &draft_content, context_a);
+        let cache_key_a = cache_key_for_input(&instructions, &runner_input_a);
+
+        fs::write(
+            Path::new("specifications/visuals/snake_visuals.md"),
+            "# Brand Identity Specification\n\n## Description\n- Version B",
+        )
+        .expect("write version b");
+        let context_b = build_specification_context(draft_path, &draft_content, HashMap::new())
+            .expect("context b");
+        let runner_input_b = build_agent_input(agent_name, &draft_content, context_b);
+        let cache_key_b = cache_key_for_input(&instructions, &runner_input_b);
+
+        assert_ne!(cache_key_a, cache_key_b);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn fit_context_to_token_limit_keeps_brand_identity_specs_when_compacting() {
+        let _cwd_guard = current_dir_lock().lock().expect("cwd lock");
+        let root = temp_root("component_brand_compact");
+        fs::create_dir_all(root.join("drafts/components")).expect("mkdir drafts");
+        fs::create_dir_all(root.join("specifications/visuals")).expect("mkdir visuals");
+        fs::write(root.join("drafts/components/button.md"), "# Button").expect("write draft");
+        let long_brand_content = format!(
+            "# Brand Identity Specification\n\n## Description\n- {}\n",
+            "brand".repeat(5000)
+        );
+        fs::write(
+            root.join("specifications/visuals/snake_visuals.md"),
+            long_brand_content,
+        )
+        .expect("write long brand spec");
+
+        let _dir_guard = CurrentDirGuard::enter(&root);
+        let draft_path = Path::new("drafts/components/button.md");
+        let draft_content = fs::read_to_string(draft_path).expect("read draft");
+        let context = build_specification_context(draft_path, &draft_content, HashMap::new())
+            .expect("build context");
+        let executor = AgentExecutor::new(
+            "create_specification_components",
+            &Config {
+                verbose: false,
+                dry_run: false,
+            },
+        )
+        .expect("executor");
+        let base_estimate = executor
+            .estimate_request_tokens(&draft_content, context.clone())
+            .expect("base estimate");
+
+        let limit = (base_estimate.saturating_sub(50)) as f64;
+        let (compacted, estimated) =
+            fit_context_to_token_limit(&executor, &draft_content, context, Some(limit))
+                .expect("fit context");
+
+        assert!(estimated as f64 <= limit);
+        let brand_specs = compacted
+            .get("brand_identity_specifications")
+            .and_then(|value| value.as_array())
+            .expect("brand specs array");
+        assert!(!brand_specs.is_empty());
+        assert!(brand_specs[0]["content"]
+            .as_str()
+            .expect("brand content")
+            .contains("Brand Identity Specification"));
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -892,6 +892,16 @@ fn finalize_specification_output(
         } else {
             extract_actionable_specification_blockers(&normalized_spec_content, false)
         };
+        if is_component_draft_path(draft_file, DRAFTS_DIR) {
+            let unresolved =
+                unresolved_component_references(&normalized_spec_content, &additional_context);
+            actionable.extend(unresolved.into_iter().map(|name| {
+                format!(
+                    "Which existing component should satisfy `{}`? It is not defined in `drafts/components` or `component_drafts`.",
+                    name
+                )
+            }));
+        }
         has_blocking_ambiguities = !actionable.is_empty();
         if has_blocking_ambiguities {
             if is_component_draft_path(draft_file, DRAFTS_DIR) {
@@ -2043,6 +2053,75 @@ fn extract_blocking_ambiguities_section(content: &str) -> Option<String> {
 
 fn extract_component_clarification_questions_section(content: &str) -> Option<String> {
     extract_section(content, "Clarification Questions (Blocking)")
+}
+
+fn normalize_component_reference_name(name: &str) -> String {
+    name.trim()
+        .trim_start_matches('-')
+        .trim_start_matches('*')
+        .trim()
+        .trim_matches('`')
+        .trim_matches('*')
+        .trim_matches('_')
+        .trim()
+        .to_ascii_lowercase()
+}
+
+fn extract_subcomponent_reference_names(content: &str) -> Vec<String> {
+    let Some(section) = extract_section(content, "Subcomponents") else {
+        return Vec::new();
+    };
+
+    let mut names = Vec::new();
+    for (_, bullet) in extract_bullets_with_indent(&section) {
+        let bullet = bullet
+            .trim_start_matches("- ")
+            .trim_start_matches("* ")
+            .trim();
+        let candidate = bullet
+            .split_once(':')
+            .map(|(name, _)| name)
+            .or_else(|| bullet.split_once(" - ").map(|(name, _)| name))
+            .unwrap_or(bullet);
+        let candidate = candidate.trim();
+        if candidate.is_empty() || candidate.eq_ignore_ascii_case("none.") {
+            continue;
+        }
+        names.push(candidate.trim_matches('`').trim().to_string());
+    }
+
+    names
+}
+
+fn collect_known_component_names(context: &HashMap<String, serde_json::Value>) -> HashSet<String> {
+    let mut names = HashSet::new();
+    for key in ["draft_component_names", "component_library_names"] {
+        if let Some(values) = context.get(key).and_then(|value| value.as_array()) {
+            for value in values {
+                if let Some(name) = value.as_str() {
+                    names.insert(normalize_component_reference_name(name));
+                }
+            }
+        }
+    }
+    names
+}
+
+fn unresolved_component_references(
+    content: &str,
+    context: &HashMap<String, serde_json::Value>,
+) -> Vec<String> {
+    let known_names = collect_known_component_names(context);
+    let mut unresolved = Vec::new();
+    for name in extract_subcomponent_reference_names(content) {
+        let normalized = normalize_component_reference_name(&name);
+        if !normalized.is_empty() && !known_names.contains(&normalized) {
+            unresolved.push(name);
+        }
+    }
+    unresolved.sort_by_key(|name| name.to_ascii_lowercase());
+    unresolved.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
+    unresolved
 }
 
 fn extract_actionable_blocking_bullets_from_section(section: Option<String>) -> Vec<String> {
@@ -5777,6 +5856,124 @@ placeholder
             actionable,
             vec!["- What variants does Button support?".to_string()]
         );
+    }
+
+    #[test]
+    fn component_draft_priority_allows_designer_owned_components_and_blocks_unknowns() {
+        let _guard = current_dir_lock().lock().expect("lock current dir");
+        let root = temp_root("component_priority");
+        fs::create_dir_all(root.join("drafts/components")).expect("mkdir drafts");
+        fs::create_dir_all(root.join("component_drafts")).expect("mkdir library");
+        fs::create_dir_all(root.join("specifications/components")).expect("mkdir specs");
+
+        let card_draft = r#"# Card - Component Specification
+
+## Component Metadata
+
+### Name
+
+Card
+
+### Description
+
+Card groups related content and actions into a single unit.
+
+---
+
+## Visual Structure
+
+### Subcomponents
+
+- `Badge`: used for optional status or category markers.
+- `Image`: used for optional preview imagery.
+- `Avatar`: used for an optional leading profile cue.
+- `Button`: used for a primary action.
+- `Link`: used for a secondary action.
+- `Heading`: used for the title.
+"#;
+        fs::write(root.join("drafts/components/card.md"), card_draft).expect("write card draft");
+        fs::write(root.join("drafts/components/badge.md"), "# Badge - Component Specification")
+            .expect("write badge draft");
+        fs::write(root.join("drafts/components/image.md"), "# Image - Component Specification")
+            .expect("write image draft");
+        fs::write(
+            root.join("component_drafts/button.md"),
+            "# Button\n\n## Description\nFallback button.",
+        )
+        .expect("write button library");
+        fs::write(
+            root.join("component_drafts/link.md"),
+            "# Link\n\n## Description\nFallback link.",
+        )
+        .expect("write link library");
+        fs::write(
+            root.join("component_drafts/heading.md"),
+            "# Heading\n\n## Description\nFallback heading.",
+        )
+        .expect("write heading library");
+
+        let _dir = CurrentDirGuard::enter(&root);
+        let draft_path = Path::new("drafts/components/card.md");
+        let draft_content = fs::read_to_string(draft_path).expect("read draft");
+        let additional = build_specification_context(draft_path, &draft_content, HashMap::new())
+            .expect("build component context");
+
+        let spec_content = r#"# Card
+
+## Component Metadata
+- Name
+- Description
+
+## Visual Structure
+- layout structure
+- content areas or slots
+- alignment and spacing rules
+
+### Subcomponents
+- `Badge`: used for optional status or category markers.
+- `Image`: used for optional preview imagery.
+- `Avatar`: used for an optional leading profile cue.
+- `Button`: used for a primary action.
+- `Link`: used for a secondary action.
+- `Heading`: used for the title.
+
+## Variants
+- documented visual variants only
+
+## States
+- documented states only
+
+## Properties
+- configurable inputs only
+
+## Accessibility Notes
+- keyboard expectations
+- ARIA or accessibility considerations if relevant
+"#;
+
+        let outcome = finalize_specification_output(
+            &draft_content,
+            draft_path,
+            "card",
+            spec_content.to_string(),
+            additional,
+        )
+        .expect("finalize component spec");
+
+        match outcome {
+            ProcessSpecOutcome::CreatedWithBlockingAmbiguities { actionable, .. } => {
+                assert!(actionable.iter().any(|item| item.contains("Avatar")));
+                assert!(!actionable.iter().any(|item| item.contains("Badge")));
+                assert!(!actionable.iter().any(|item| item.contains("Image")));
+                assert!(!actionable.iter().any(|item| item.contains("Button")));
+                assert!(!actionable.iter().any(|item| item.contains("Link")));
+                assert!(!actionable.iter().any(|item| item.contains("Heading")));
+            }
+            other => panic!("expected blocking component outcome, got {:?}", other),
+        }
+
+        drop(_dir);
+        let _ = fs::remove_dir_all(&root);
     }
 
     fn valid_brand_spec_with_blocker() -> String {

--- a/src/cli/pipeline_context.rs
+++ b/src/cli/pipeline_context.rs
@@ -131,6 +131,20 @@ fn collect_component_artifacts(root: &Path) -> Result<Vec<serde_json::Value>> {
     Ok(artifacts)
 }
 
+fn collect_brand_identity_artifacts(specifications_root: &Path) -> Result<Vec<serde_json::Value>> {
+    let mut artifacts = Vec::new();
+    for folder in ["brands", "visuals"] {
+        let mut folder_artifacts = collect_markdown_artifacts(&specifications_root.join(folder))?;
+        artifacts.append(&mut folder_artifacts);
+    }
+    artifacts.sort_by(|a, b| {
+        let a_path = a.get("path").and_then(|v| v.as_str()).unwrap_or_default();
+        let b_path = b.get("path").and_then(|v| v.as_str()).unwrap_or_default();
+        a_path.cmp(b_path)
+    });
+    Ok(artifacts)
+}
+
 fn detect_duplicate_component_names(draft_file: &Path) -> Result<Vec<String>> {
     let Some(components_dir) = draft_file.parent() else {
         return Ok(Vec::new());
@@ -190,6 +204,15 @@ fn add_component_context(
     let existing_specs = collect_markdown_artifacts(&project_root.join("specifications"))?;
     if !existing_specs.is_empty() {
         context.insert("existing_specifications".to_string(), json!(existing_specs));
+    }
+
+    let brand_identity_specs =
+        collect_brand_identity_artifacts(&project_root.join("specifications"))?;
+    if !brand_identity_specs.is_empty() {
+        context.insert(
+            "brand_identity_specifications".to_string(),
+            json!(brand_identity_specs),
+        );
     }
 
     let draft_component_refs = collect_component_artifacts(&project_root.join("drafts/components"))?;
@@ -339,6 +362,7 @@ fn build_context_variants(
         ("dependency_closure", 1200usize, 8usize),
         ("mcp_context", 1200usize, 8usize),
         ("implemented_dependencies", 800usize, 6usize),
+        ("brand_identity_specifications", 1200usize, 8usize),
         ("draft_component_references", 1200usize, 8usize),
         ("component_library_references", 1200usize, 8usize),
     ];

--- a/src/cli/pipeline_context.rs
+++ b/src/cli/pipeline_context.rs
@@ -73,6 +73,64 @@ fn collect_markdown_artifacts(root: &Path) -> Result<Vec<serde_json::Value>> {
     Ok(artifacts)
 }
 
+fn declared_component_name(content: &str, fallback: &str) -> String {
+    let heading = content
+        .lines()
+        .find(|line| line.trim_start().starts_with('#'))
+        .map(|line| line.trim_start().trim_start_matches('#').trim())
+        .unwrap_or(fallback);
+
+    heading
+        .strip_suffix(" - Component Specification")
+        .unwrap_or(heading)
+        .trim()
+        .to_string()
+}
+
+fn collect_component_artifacts(root: &Path) -> Result<Vec<serde_json::Value>> {
+    fn visit(dir: &Path, out: &mut Vec<serde_json::Value>) -> Result<()> {
+        if !dir.exists() {
+            return Ok(());
+        }
+
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                visit(&path, out)?;
+                continue;
+            }
+
+            if path.extension().and_then(|s| s.to_str()) != Some("md") {
+                continue;
+            }
+
+            let content = fs::read_to_string(&path)?;
+            let fallback_name = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or_default();
+            let name = declared_component_name(&content, fallback_name);
+            out.push(json!({
+                "name": name,
+                "path": path.to_string_lossy().to_string(),
+                "content": content,
+            }));
+        }
+
+        Ok(())
+    }
+
+    let mut artifacts = Vec::new();
+    visit(root, &mut artifacts)?;
+    artifacts.sort_by(|a, b| {
+        let a_path = a.get("path").and_then(|v| v.as_str()).unwrap_or_default();
+        let b_path = b.get("path").and_then(|v| v.as_str()).unwrap_or_default();
+        a_path.cmp(b_path)
+    });
+    Ok(artifacts)
+}
+
 fn detect_duplicate_component_names(draft_file: &Path) -> Result<Vec<String>> {
     let Some(components_dir) = draft_file.parent() else {
         return Ok(Vec::new());
@@ -134,11 +192,59 @@ fn add_component_context(
         context.insert("existing_specifications".to_string(), json!(existing_specs));
     }
 
-    let library_refs = collect_markdown_artifacts(&project_root.join("component_drafts"))?;
-    if !library_refs.is_empty() {
+    let draft_component_refs = collect_component_artifacts(&project_root.join("drafts/components"))?;
+    if !draft_component_refs.is_empty() {
+        let draft_component_names = draft_component_refs
+            .iter()
+            .filter_map(|artifact| artifact.get("name").and_then(|v| v.as_str()))
+            .map(|name| name.to_string())
+            .collect::<Vec<_>>();
+        context.insert(
+            "draft_component_references".to_string(),
+            json!(draft_component_refs),
+        );
+        context.insert(
+            "draft_component_names".to_string(),
+            json!(draft_component_names),
+        );
+    }
+
+    let draft_component_name_set = context
+        .get("draft_component_names")
+        .and_then(|value| value.as_array())
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value.as_str())
+                .map(|name| name.to_string())
+                .collect::<std::collections::HashSet<_>>()
+        })
+        .unwrap_or_default();
+
+    let library_refs = collect_component_artifacts(&project_root.join("component_drafts"))?;
+    let filtered_library_refs: Vec<serde_json::Value> = library_refs
+        .into_iter()
+        .filter(|artifact| {
+            artifact
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(|name| !draft_component_name_set.contains(name))
+                .unwrap_or(true)
+        })
+        .collect();
+    if !filtered_library_refs.is_empty() {
+        let component_library_names = filtered_library_refs
+            .iter()
+            .filter_map(|artifact| artifact.get("name").and_then(|v| v.as_str()))
+            .map(|name| name.to_string())
+            .collect::<Vec<_>>();
         context.insert(
             "component_library_references".to_string(),
-            json!(library_refs),
+            json!(filtered_library_refs),
+        );
+        context.insert(
+            "component_library_names".to_string(),
+            json!(component_library_names),
         );
     }
 
@@ -233,6 +339,8 @@ fn build_context_variants(
         ("dependency_closure", 1200usize, 8usize),
         ("mcp_context", 1200usize, 8usize),
         ("implemented_dependencies", 800usize, 6usize),
+        ("draft_component_references", 1200usize, 8usize),
+        ("component_library_references", 1200usize, 8usize),
     ];
     let mut compact = base_context.clone();
     let mut changed = false;

--- a/src/registries/embedded_agent_assets.rs
+++ b/src/registries/embedded_agent_assets.rs
@@ -92,4 +92,13 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn component_spec_agent_uses_runtime_brand_identity_input() {
+        let content = embedded_agent_spec("create_specification_components.yml")
+            .expect("embedded component spec agent");
+        assert!(content.contains("brand_identity_specifications"));
+        assert!(content.contains("provided for this run"));
+        assert!(content.contains("never assume a built-in default brand"));
+    }
 }

--- a/tests/snake/drafts/components/badge.md
+++ b/tests/snake/drafts/components/badge.md
@@ -1,0 +1,66 @@
+# Badge - Component Specification
+
+## Component Metadata
+
+### Name
+
+Badge
+
+### Description
+
+A Badge is a compact visual label used to indicate status, category, or priority. It should be used for short, high-signal markers that support a larger component without taking over the hierarchy.
+
+---
+
+## Visual Structure
+
+The Badge is a compact inline element with short text and optional emphasis styling.
+
+### Layout Structure
+
+Inline and compact, with content centered inside a small rounded surface.
+
+### Content Areas or Slots
+
+- **Content slot (required):** Short text or label content.
+
+### Alignment and Spacing Rules
+
+- Content is centered vertically and horizontally.
+- Padding remains tight so the badge stays secondary to surrounding content.
+
+---
+
+## Variants
+
+- **Neutral:** Uses subdued styling for general labels.
+- **Success:** Used for positive or complete states.
+- **Warning:** Used for cautionary states.
+- **Destructive:** Used for error or high-risk states.
+
+---
+
+## States
+
+### Default
+
+The badge is visible and stable.
+
+### Disabled
+
+The badge appears muted when it should not draw emphasis.
+
+---
+
+## Properties
+
+- `label`: String. Required. The badge text.
+- `variant`: `neutral` | `success` | `warning` | `destructive`.
+
+---
+
+## Accessibility Notes
+
+### ARIA Roles and Accessibility Considerations
+
+- The badge should be read as text unless it conveys a meaningful state that needs additional announcement.

--- a/tests/snake/drafts/components/card.md
+++ b/tests/snake/drafts/components/card.md
@@ -1,0 +1,156 @@
+# Card - Component Specification
+
+## Component Metadata
+
+### Name
+
+Card
+
+### Description
+
+A Card is a composed surface component used to group related content, status, and actions into a single readable unit. It should be used for previews, summaries, feature highlights, and modular content blocks where a clear boundary helps scanning and comparison. This component is intentionally defined as a larger container that relies on existing library components for many of its internal building blocks.
+
+---
+
+## Visual Structure
+
+The Card is a bounded container with a clear outer surface, internal padding, and a predictable vertical reading order. A typical card includes a media or visual accent area, a header group, a body content area, optional metadata, and a footer action area. Depending on context, the card may present as a static information block or as an interactive summary that links to more detail.
+
+### Layout Structure
+
+Primarily vertical and stacked. The default layout follows a top-to-bottom structure with optional horizontal arrangements inside local regions such as metadata rows or action groups. Internal grouping should use existing layout container patterns rather than inventing one-off spacing behavior.
+
+### Subcomponents
+
+- `Layout-Containers`: used to organize the card into stacked, row, grid, and section-like internal regions.
+- `Button`: used for primary or secondary actions in the footer or action row.
+- `Heading`: used for the main title and optional section labels inside the card.
+- `Text`: used for supporting copy, labels, and small metadata strings.
+- `Link`: used when the card exposes secondary navigation or inline destinations.
+- `Badge`: used for optional status, category, or priority markers.
+- `Image`: used for optional preview imagery, illustration, or thumbnail content.
+- `Avatar`: used for an optional leading profile cue.
+
+### Content Areas or Slots
+
+Include:
+
+- **Media slot (optional):** A top or side-aligned region for imagery, illustration, thumbnail content, or a decorative preview surface.
+- **Header slot (required):** The primary identification area containing the card title and optional status or category marker.
+- **Body slot (required):** Supporting description, summary content, or preview information that explains the card's purpose.
+- **Metadata slot (optional):** Compact supporting details such as date, author, tags, counts, or status text.
+- **Action slot (optional):** A region for one primary action and, when needed, one or more secondary actions.
+
+### Alignment and Spacing Rules
+
+- Content is aligned to a consistent internal grid with shared left and right padding.
+- Vertical spacing should separate regions clearly: header to body is tighter than body to action area.
+- Metadata rows and action rows may use horizontal layout containers with consistent gaps between items.
+- If media is present, its relationship to the content block should feel intentional: edge-to-edge within the card frame or inset as part of the card padding system.
+- Text should align to the same primary content edge even when badges, icons, or actions are present.
+- Footer actions should align as a group and should not visually compete with the title or summary content.
+
+---
+
+## Variants
+
+- **Informational:** Used for summaries, read-only previews, and modular content blocks where scanning matters more than immediate action. Uses restrained emphasis and balanced spacing.
+- **Interactive:** Used when the card itself is clickable or acts as a prominent navigation target. The whole surface communicates affordance while preserving clear internal hierarchy.
+- **Feature:** Used for highlighted content, promotions, or important surfaced content. May use stronger media presence, larger spacing, or more prominent headline treatment.
+- **Compact:** Used in dense lists or dashboards where the same card pattern must repeat in limited space. Reduces padding and truncates secondary detail before reducing title clarity.
+- **Status:** Used when the card needs to foreground a badge, state, or workflow condition such as success, warning, draft, or blocked.
+
+For each variant, clarify:
+
+- Informational is best when the content should feel neutral and readable.
+- Interactive differs by emphasizing hover, focus, and click affordance across the full surface.
+- Feature differs by increasing visual prominence through media, spacing, or stronger headline hierarchy.
+- Compact differs by compressing layout rhythm while retaining recognizable regions.
+- Status differs by making state communication more prominent than decorative content.
+
+---
+
+## States
+
+### Default
+
+The card surface is visible and stable, with all regions rendered at full opacity. The hierarchy should be immediately legible, with the title as the dominant entry point and supporting content arranged beneath it.
+
+### Hover
+
+For interactive cards, the surface may lift slightly through shadow, border contrast, or background shift. Hover feedback should apply to the container without causing layout shift. For non-interactive cards, hover should not imply clickability.
+
+### Active
+
+Interactive cards may show a pressed state through reduced elevation, subtle scale change, or darker surface treatment. If the card contains internal buttons or links, their active states remain independent and should not visually conflict with the card's own press feedback.
+
+### Disabled
+
+The card appears unavailable through reduced contrast and suppressed affordance. Interactive behaviors are blocked. Any internal actions inside a disabled card should also be unavailable or omitted.
+
+### Loading (if applicable)
+
+Loading cards preserve the final layout footprint to avoid reflow in lists or grids. Placeholder regions may stand in for media, title, text, metadata, and actions. The overall structure should remain recognizable even while content is not yet available.
+
+---
+
+## Properties
+
+- `title`: String. Required. The primary heading for the card.
+- `description`: String or rich text summary. Optional but expected in most informational uses.
+- `variant`: `informational` | `interactive` | `feature` | `compact` | `status`.
+- `media`: Optional media content, image reference, or illustrative surface.
+- `badge`: Optional status, category, or emphasis label.
+- `metadata`: Optional list or grouped set of supporting details.
+- `actions`: Optional action set, typically one primary action plus secondary actions or links.
+- `orientation`: `vertical` | `horizontal`. Controls whether media and content stack or sit side by side.
+- `interactive`: Boolean. When true, the whole card behaves as a target and should expose hover, active, and focus treatment.
+- `selected`: Boolean. Optional. Indicates the card is currently chosen within a set.
+- `disabled`: Boolean. Optional. Prevents interaction and applies disabled styling.
+- `loading`: Boolean. Optional. Replaces content with loading placeholders while preserving size and structure.
+
+---
+
+## Accessibility Notes
+
+### Keyboard Interaction Expectations
+
+- If the whole card is interactive, it must be reachable via `Tab` as a single focus target unless the pattern intentionally exposes multiple internal controls.
+- `Enter` and `Space` should activate the card when it behaves like a button-like surface.
+- Internal buttons and links must remain reachable in a predictable focus order when present.
+- If both the card surface and internal actions are interactive, focus behavior should avoid duplicate or confusing activation paths.
+
+### ARIA Roles and Accessibility Considerations
+
+- Non-interactive cards should usually render as semantic grouping content such as `<section>`, `<article>`, or `<div>` depending on context.
+- Interactive cards should use the semantic element that best matches behavior, such as a link for navigation or a button-like pattern for in-place actions.
+- The card must expose a clear accessible name, typically derived from the title.
+- Status badges, counts, and metadata should be announced in a meaningful order and should not replace the title as the primary accessible identifier.
+- Loading cards should communicate busy or updating status when the card updates asynchronously.
+
+---
+
+## Optional: Usage Guidelines and Examples
+
+### Do
+
+- Use cards when content benefits from a visible boundary and predictable internal structure.
+- Reuse established library components inside the card instead of redefining bespoke child patterns.
+- Keep one dominant entry point, usually the title or primary action, so the card remains easy to scan.
+- Use compact variants for repeated collections and richer variants for featured or editorial content.
+
+### Dont
+
+- Don't overload a single card with too many competing actions.
+- Don't make a card appear clickable unless the full-surface interaction is intentional.
+- Don't mix unrelated content types inside one card just because a container is available.
+- Don't redefine internal button or layout behavior in the card spec when existing component drafts already cover those patterns.
+
+---
+
+## Notes
+
+- This document defines **one component specification** and should stay focused on that component only.
+- Internal child behavior should defer to existing component drafts where those components are already defined in the library.
+- Keep guidance implementation-agnostic unless framework-specific behavior is explicitly required.
+- Prioritize consistency across variants, states, and accessibility behavior.

--- a/tests/snake/drafts/components/image.md
+++ b/tests/snake/drafts/components/image.md
@@ -1,0 +1,69 @@
+# Image - Component Specification
+
+## Component Metadata
+
+### Name
+
+Image
+
+### Description
+
+An Image is a media component used to present a preview, illustration, or supporting visual. It should be used when a card or other composed component needs a recognizable visual anchor without adding interaction on its own.
+
+---
+
+## Visual Structure
+
+The Image is a rectangular media surface with predictable aspect ratio handling.
+
+### Layout Structure
+
+Block-level media with either cropped or contained presentation depending on context.
+
+### Content Areas or Slots
+
+- **Media slot (required):** The image content itself.
+
+### Alignment and Spacing Rules
+
+- The image fills its allotted slot cleanly.
+- Cropping or containment should preserve the intended focal point.
+
+---
+
+## Variants
+
+- **Thumbnail:** Used for compact card previews.
+- **Hero:** Used for larger feature surfaces.
+
+---
+
+## States
+
+### Default
+
+The image renders normally.
+
+### Loading
+
+The image area may show a placeholder while content loads.
+
+### Disabled
+
+The image may appear muted when it is not available.
+
+---
+
+## Properties
+
+- `src`: String. Required. The media source.
+- `alt`: String. Required. The accessible description.
+- `variant`: `thumbnail` | `hero`.
+
+---
+
+## Accessibility Notes
+
+### ARIA Roles and Accessibility Considerations
+
+- The image must always have meaningful alternative text when it conveys information.


### PR DESCRIPTION
Testing of the create_specification_component agent has been applied. All components include a: 
• Name
• Description
• Visual structure
• Variants
• States
• Properties

Brand identity is referenced by the Component Specifications. 

Ambiguities are flagged and reported to the user. 

Setup/ReadMe.md files are updated.