### PR TITLE
Refactor: brand implementation takes brand identity spec and componen…

### DIFF
--- a/agents/create_implementation_brand.yml
+++ b/agents/create_implementation_brand.yml
@@ -32,8 +32,15 @@ static_prompt: |
 
   ---
 
-  Your task is to read a completed brand identity specification and produce a fully scaffolded,
-  runnable Leptos SSR web application that applies the brand tokens as concrete styling.
+  Your task is to read a completed brand identity specification and component specifications
+  together, then produce a fully scaffolded, runnable Leptos SSR web application that applies both:
+  brand tokens as concrete styling and component-level implementation requirements.
+
+  Source expectations for this agent:
+  - Brand identity specification context comes from `specifications/visuals/*.md`.
+  - Component specification context comes from `specifications/components/*.md`.
+  - When component specification context is provided, treat it as additive and authoritative alongside
+    the brand identity specification, not as a replacement.
 
   ## Core Rules
 
@@ -203,8 +210,11 @@ static_prompt: |
 variable_prompt: |
   ## Input
 
-  Brand specification content:
+  Brand identity specification content (from `specifications/visuals/*.md`):
   {{input.context_content}}
+
+  Component specifications content (from `specifications/components/*.md`, optional; aggregated):
+  {{input.component_specifications?}}
 
   Dependency manifest (optional, authoritative):
   {{input.direct_dependencies?}}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1789,8 +1789,54 @@ fn augment_implementation_generation_context(
             "brand_scaffold_contract".to_string(),
             json!(render_brand_scaffold_contract()),
         );
+        if let Some(component_specification) = render_component_specifications()? {
+            additional_context.insert(
+                "component_specifications".to_string(),
+                json!(component_specification),
+            );
+        }
     }
     Ok(())
+}
+
+fn render_component_specifications() -> Result<Option<String>> {
+    let components_dir = Path::new(SPECIFICATIONS_DIR).join("components");
+    if !components_dir.exists() {
+        return Ok(None);
+    }
+
+    let mut spec_paths = fs::read_dir(&components_dir)
+        .with_context(|| {
+            format!(
+                "Failed to read design component specification directory {}",
+                components_dir.display()
+            )
+        })?
+        .filter_map(|entry| entry.ok().map(|item| item.path()))
+        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("md"))
+        .collect::<Vec<_>>();
+    spec_paths.sort();
+
+    if spec_paths.is_empty() {
+        return Ok(None);
+    }
+
+    let mut rendered_sections = Vec::new();
+    for path in spec_paths {
+        let content = fs::read_to_string(&path).with_context(|| {
+            format!(
+                "Failed to read design component specification {}",
+                path.display()
+            )
+        })?;
+        rendered_sections.push(format!(
+            "===COMPONENT_SPEC: {}===\n{}\n===END_COMPONENT_SPEC===",
+            path.display(),
+            content
+        ));
+    }
+
+    Ok(Some(rendered_sections.join("\n\n")))
 }
 
 fn validate_implementation_scaffold_ownership(context_files: &[PathBuf]) -> Result<()> {
@@ -5546,6 +5592,7 @@ placeholder
             brand_context.get("brand_scaffold_contract"),
             Some(&json!(render_brand_scaffold_contract()))
         );
+        assert!(brand_context.get("component_specifications").is_none());
 
         let mut non_brand_context = HashMap::new();
         augment_implementation_generation_context(
@@ -5554,6 +5601,50 @@ placeholder
         )
         .expect("augment non-brand context");
         assert!(!non_brand_context.contains_key("brand_scaffold_contract"));
+        assert!(!non_brand_context.contains_key("component_specifications"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn implementation_context_includes_design_component_specs_for_brand_implementation() {
+        let _cwd_guard = current_dir_lock().lock().expect("cwd lock");
+        let root = temp_root("brand_impl_component_specs");
+        fs::create_dir_all(root.join("specifications/brands")).expect("mkdir brands");
+        fs::create_dir_all(root.join("specifications/components")).expect("mkdir components");
+        fs::write(
+            root.join("specifications/brands/acme.md"),
+            "# Brand Identity Specification\n\n## Description\nplaceholder",
+        )
+        .expect("write brand spec");
+        fs::write(
+            root.join("specifications/components/button.md"),
+            "# Button Specification\n\n## Purpose\nA primary action button.",
+        )
+        .expect("write component spec");
+        fs::write(
+            root.join("specifications/components/input.md"),
+            "# Input Specification\n\n## Purpose\nA text input field.",
+        )
+        .expect("write component spec");
+
+        let _dir_guard = CurrentDirGuard::enter(&root);
+
+        let mut brand_context = HashMap::new();
+        augment_implementation_generation_context(
+            Path::new("specifications/brands/acme.md"),
+            &mut brand_context,
+        )
+        .expect("augment brand context");
+
+        let rendered = brand_context
+            .get("component_specifications")
+            .and_then(|value| value.as_str())
+            .expect("component specifications context");
+        assert!(rendered.contains("===COMPONENT_SPEC: specifications/components/button.md==="));
+        assert!(rendered.contains("===COMPONENT_SPEC: specifications/components/input.md==="));
+        assert!(rendered.contains("# Button Specification"));
+        assert!(rendered.contains("# Input Specification"));
 
         let _ = fs::remove_dir_all(&root);
     }


### PR DESCRIPTION
* I would like someone to look at the push because I was on the task alone.

* Refactored the create_implementation_brand.yml and mod.rs to to be able to take two seperate specifications: brand identity spec and component sepc , when running implementation in future.


* If anyone wants info (putting this in shared ressources)

**Info about '?' in the create_implementation_brand.yml.

Template Optional Fields (?) Explained
In our agent templates, placeholders like {{input.some_key}} and {{input.some_key?}} are not the same.

{{input.some_key}} means the field is expected/present.
{{input.some_key?}} means the field is optional.
What the trailing ? means
The ? is template syntax, not part of the input key name.
Real key name: component_specifications
Optional placeholder form: {{input.component_specifications?}}
So this is correct:

Key in payload: component_specifications
Template usage (optional): {{input.component_specifications?}}
Not this:

Key named component_specifications? (this key does not exist)
Runtime behavior
When rendering:

If component_specifications exists:
{{input.component_specifications?}} renders its value.
If it does not exist:
{{input.component_specifications?}} renders empty (no hard failure).
Why we use optional placeholders
Optional placeholders are useful when context may or may not be present across different runs, while keeping one stable template.

Example in our flow:

Brand identity spec is usually required context.
Component specs may be present depending on command/scope.
Therefore component specs are referenced with ?.
Rule of thumb for authors
Use {{input.key}} when the field is mandatory for correct behavior.
Use {{input.key?}} when the field is legitimately optional.
Keep key naming consistent in code (component_specifications), and only use ? in template placeholders.
If you want, I can also turn this into a short docs/templating.md snippet in the repo so everyone has a canonical reference.